### PR TITLE
Drop needless assert from `FilesystemObject` config option

### DIFF
--- a/mkdocs/config/config_options.py
+++ b/mkdocs/config/config_options.py
@@ -383,9 +383,7 @@ class FilesystemObject(Type):
             value = os.path.join(self.config_dir, value)
         if self.exists and not self.existence_test(value):
             raise ValidationError(f"The path {value} isn't an existing {self.name}.")
-        value = os.path.abspath(value)
-        assert isinstance(value, str)
-        return value
+        return os.path.abspath(value)
 
 
 class Dir(FilesystemObject):


### PR DESCRIPTION
`FilesystemObject` validates previously that `value` is a string, so it's impossible that `os.path.abspath(value)` returns a string.

Note also that `assert`s are removed if Python runs with optimizations enabled, so adding `assert`s in the source code is a bad practice:

```bash
$ python3 -O -c "assert False"
$ python3 -c "assert False"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError
```